### PR TITLE
Migrate TranslucentModalHostView.java to androidX

### DIFF
--- a/android/src/main/java/com/mf/translucentmodal/TranslucentModalHostView.java
+++ b/android/src/main/java/com/mf/translucentmodal/TranslucentModalHostView.java
@@ -7,7 +7,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.graphics.Color;
 import android.os.Build;
-import android.support.v4.view.ViewCompat;
+import androidx.core.view.ViewCompat;
 import android.view.View;
 import android.view.Window;
 import android.view.WindowInsets;


### PR DESCRIPTION
Needed to update this line in order to use this library with my project, which uses AndroidX. 